### PR TITLE
Implemented StableDeref trait, however this required some refactoring in the FlatMessage trait.

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -341,20 +341,20 @@ impl<'a, T: FlatMessage<'a>> FlatMessage<'a> for Wrapper<T> {
         self.0.serialize_to(output, config)
     }
 
-    fn deserialize_from(input: &'a Storage) -> std::result::Result<Self, flat_message::Error>
+    fn deserialize_from_slice(input: &'a [u8]) -> std::result::Result<Self, flat_message::Error>
     where
         Self: Sized,
     {
-        unsafe { Self::deserialize_from_unchecked(input) }
+        unsafe { Self::deserialize_from_slice_unchecked(input) }
     }
 
-    unsafe fn deserialize_from_unchecked(
-        input: &'a Storage,
+    unsafe fn deserialize_from_slice_unchecked(
+        input: &'a [u8],
     ) -> std::result::Result<Self, flat_message::Error>
     where
         Self: Sized,
     {
-        Ok(Wrapper(T::deserialize_from_unchecked(input)?))
+        Ok(Wrapper(T::deserialize_from_slice_unchecked(input)?))
     }
 }
 

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -6,7 +6,7 @@ use ascii_table::{Align, AsciiTable};
 use clap::Parser;
 use clap::Subcommand;
 use clap::ValueEnum;
-use flat_message::{FlatMessage, FlatMessageOwned, Storage};
+use flat_message::{FlatMessage, FlatMessageOwned, Storage, StorageRef};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::HashSet;
@@ -341,20 +341,20 @@ impl<'a, T: FlatMessage<'a>> FlatMessage<'a> for Wrapper<T> {
         self.0.serialize_to(output, config)
     }
 
-    fn deserialize_from_slice(input: &'a [u8]) -> std::result::Result<Self, flat_message::Error>
+    fn deserialize_from_ref(input: &'a StorageRef) -> std::result::Result<Self, flat_message::Error>
     where
         Self: Sized,
     {
-        unsafe { Self::deserialize_from_slice_unchecked(input) }
+        unsafe { Self::deserialize_from_ref_unchecked(input) }
     }
 
-    unsafe fn deserialize_from_slice_unchecked(
-        input: &'a [u8],
+    unsafe fn deserialize_from_ref_unchecked(
+        input: &'a StorageRef,
     ) -> std::result::Result<Self, flat_message::Error>
     where
         Self: Sized,
     {
-        Ok(Wrapper(T::deserialize_from_slice_unchecked(input)?))
+        Ok(Wrapper(T::deserialize_from_ref_unchecked(input)?))
     }
 }
 

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -32,6 +32,7 @@
   - [Ignoring fields](chapter-4/ignoring_fields.md)
   - [Checksum Validation](chapter-4/checksum_validation.md)
   - [Message Name Validation](chapter-4/message_name_validation.md)
+  - [Owned Zero-Copy Structures](chapter-4/owned_zero_copy.md)
 - [Benchmarks & Performance](chapter-5/benchmarks.md)
   - [Performance Results](chapter-5/performance_results.md)
     - [Multiple Fields](chapter-5/results/multiple_fields.md)

--- a/book/chapter-1/core_concepts.md
+++ b/book/chapter-1/core_concepts.md
@@ -98,14 +98,30 @@ pub trait FlatMessage<'a> {
     fn serialize_to(&self, output: &mut Storage, config: Config) -> Result<(), Error>;
     
     // Deserialize data from a buffer (with validation)
-    fn deserialize_from(input: &'a Storage) -> Result<Self, Error>
+    fn deserialize_from_slice(input: &'a [u8]) -> Result<Self, Error>
     where
         Self: Sized;
     
     // Deserialize without validation (faster, but unsafe)
-    unsafe fn deserialize_from_unchecked(input: &'a Storage) -> Result<Self, Error>
+    unsafe fn deserialize_from_slice_unchecked(input: &'a [u8]) -> Result<Self, Error>
     where
         Self: Sized;
+
+    // Deserialize directly from a Storage instance (provided)
+    fn deserialize_from(input: &'a Storage) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Self::deserialize_from_slice(input.as_slice())
+    }
+
+    // Deserialize directly from a Storage instance, without validation (provided)
+    unsafe fn deserialize_from_unchecked(input: &'a Storage) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        unsafe { Self::deserialize_from_slice_unchecked(input.as_slice()) }
+    }
 }
 ```
 
@@ -144,6 +160,8 @@ let restored_point = unsafe {
     Point::deserialize_from_unchecked(&storage)?
 };
 ```
+
+You can also use the `deserialize_from_slice` / `deserialize_from_slice_unchecked` APIs depending on your use case.
 
 ## Zero-Copy Deserialization
 

--- a/book/chapter-1/core_concepts.md
+++ b/book/chapter-1/core_concepts.md
@@ -97,13 +97,13 @@ pub trait FlatMessage<'a> {
     // Serialize data to a Storage buffer
     fn serialize_to(&self, output: &mut Storage, config: Config) -> Result<(), Error>;
     
-    // Deserialize data from a buffer (with validation)
-    fn deserialize_from_slice(input: &'a [u8]) -> Result<Self, Error>
+    // Deserialize data from a StorageRef (with validation)
+    fn deserialize_from_ref(input: &'a StorageRef) -> Result<Self, Error>
     where
         Self: Sized;
     
-    // Deserialize without validation (faster, but unsafe)
-    unsafe fn deserialize_from_slice_unchecked(input: &'a [u8]) -> Result<Self, Error>
+    // Deserialize from a StorageRef without validation (faster, but unsafe)
+    unsafe fn deserialize_from_ref_unchecked(input: &'a StorageRef) -> Result<Self, Error>
     where
         Self: Sized;
 
@@ -112,7 +112,7 @@ pub trait FlatMessage<'a> {
     where
         Self: Sized,
     {
-        Self::deserialize_from_slice(input.as_slice())
+        Self::deserialize_from_ref(input.as_ref())
     }
 
     // Deserialize directly from a Storage instance, without validation (provided)
@@ -120,7 +120,7 @@ pub trait FlatMessage<'a> {
     where
         Self: Sized,
     {
-        unsafe { Self::deserialize_from_slice_unchecked(input.as_slice()) }
+        unsafe { Self::deserialize_from_ref_unchecked(input.as_ref()) }
     }
 }
 ```
@@ -161,7 +161,7 @@ let restored_point = unsafe {
 };
 ```
 
-You can also use the `deserialize_from_slice` / `deserialize_from_slice_unchecked` APIs depending on your use case.
+The `deserialize_from_ref` / `deserialize_from_ref_unchecked` APIs can be useful when using wrappers like [yoke::Yoke](https://docs.rs/yoke/latest/yoke/struct.Yoke.html). See [Owned Zero-Copy Structures](../chapter-4/owned_zero_copy.md) for an example.
 
 ## Zero-Copy Deserialization
 

--- a/book/chapter-4/advanced_features.md
+++ b/book/chapter-4/advanced_features.md
@@ -5,3 +5,4 @@ While FlatMessage provides a lot of flexibility and power out of the box, there 
 * how to set default values
 * how to ignore fields
 * how to use checksums and validation
+* how to move zero-copy structures along with their storage, in an owned manner

--- a/book/chapter-4/owned_zero_copy.md
+++ b/book/chapter-4/owned_zero_copy.md
@@ -1,0 +1,89 @@
+# Owned Zero-Copy
+
+One of the main benefits of FlatMessage is its zero-copy deserialization capabilities. When you deserialize a message that contains references (like `&str` or `&[u8]`), the resulting structure borrows directly from the `Storage` buffer.
+
+While this is highly efficient, it introduces a lifetime constraint: the deserialized structure cannot outlive the `Storage` instance it was deserialized from.
+
+```rust
+use flat_message::*;
+
+#[derive(FlatMessage)]
+struct Message<'a> {
+    content: &'a str,
+}
+
+// This function will not compile!
+fn get_message() -> Result<Message<'static>, Error> {
+    let mut storage = Storage::default();
+    // ... receive data into storage ...
+    
+    let message = Message::deserialize_from(&storage)?;
+    
+    // ERROR: returns a value referencing data owned by the current function
+    Ok(message)
+}
+```
+
+This makes it difficult to return the deserialized message from a function, pass it across thread boundaries, or store it in a struct alongside its backing buffer.
+
+## The Solution: The `yoke` Crate
+
+To solve this problem, you can use the [`yoke`](https://docs.rs/yoke/latest/yoke/) crate. `yoke` allows you to "yoke" (attach) a zero-copy deserialized object to the source it was deserialized from (known as a "cart"), producing a type that owns its data and can be moved around freely.
+
+### Enabling `stable_deref`
+
+For `yoke` to work safely, it needs a guarantee that the memory location of the buffer won't change when the cart is moved. This is represented by the `StableDeref` trait from the `stable_deref_trait` crate.
+
+FlatMessage provides an implementation of `StableDeref` for its `Storage` type, but it is gated behind a feature flag. You must enable the `stable_deref` feature in your `Cargo.toml`:
+
+```toml
+[dependencies]
+flat_message = { version = "...", features = ["stable_deref"] }
+yoke = { version = "0.7", features = ["derive"] }
+```
+
+### Using `Yoke` with FlatMessage
+
+Once the feature is enabled, you can use `Yoke` to bundle your deserialized structure and the `Storage` instance together:
+
+```rust
+use flat_message::*;
+use yoke::{Yoke, Yokeable};
+
+// 1. Derive Yokeable on your structure
+#[derive(FlatMessage, Debug, PartialEq, Eq, Yokeable)]
+struct Message<'a> {
+    content: &'a str,
+    id: u32,
+}
+
+fn process_data() {
+    // Create and serialize some data
+    let original = Message { content: "Hello, World!", id: 42 };
+    let mut storage = Storage::default();
+    original.serialize_to(&mut storage, Config::default()).unwrap();
+
+    // 2. Attach the deserialized structure to the Storage "cart"
+    // The resulting `yoked` object owns the storage and can be moved around!
+    let yoked: Yoke<Message<'static>, Storage> = Yoke::attach_to_cart(storage, |slice| {
+        // Deserialize from the slice provided by yoke
+        Message::deserialize_from_slice(slice).expect("Failed to deserialize")
+    });
+
+    // 3. Access the deserialized data using `.get()`
+    let message: &Message<'_> = yoked.get();
+    
+    assert_eq!(message.content, "Hello, World!");
+    assert_eq!(message.id, 42);
+}
+```
+
+### How it Works
+
+1. We derive `Yokeable` on our `Message<'a>` struct. This tells `yoke` how to handle the lifetimes.
+2. We use `Yoke::attach_to_cart`. We pass it our `Storage` instance (which takes ownership of it) and a closure.
+3. The closure receives a `&[u8]` slice that is guaranteed to live as long as the `Storage` instance. We use FlatMessage's `deserialize_from_slice` to parse the data.
+4. The resulting `Yoke<Message<'static>, Storage>` is a self-contained, owned type. It has no lifetime parameters and can be returned from functions, stored in structs, or sent across threads (if the underlying types are `Send`).
+5. When you need to access the data, you call `.get()`, which returns a reference tied to the lifetime of the `Yoke` object itself.
+
+This pattern gives you the best of both worlds: the extreme performance of zero-copy deserialization, combined with the ergonomics of owned types.

--- a/book/chapter-4/owned_zero_copy.md
+++ b/book/chapter-4/owned_zero_copy.md
@@ -65,9 +65,9 @@ fn process_data() {
 
     // 2. Attach the deserialized structure to the Storage "cart"
     // The resulting `yoked` object owns the storage and can be moved around!
-    let yoked: Yoke<Message<'static>, Storage> = Yoke::attach_to_cart(storage, |slice| {
-        // Deserialize from the slice provided by yoke
-        Message::deserialize_from_slice(slice).expect("Failed to deserialize")
+    let yoked: Yoke<Message<'static>, Storage> = Yoke::attach_to_cart(storage, |storage_ref| {
+        // Deserialize from the the ref provided by yoke
+        Message::deserialize_from_ref(storage_ref).expect("Failed to deserialize")
     });
 
     // 3. Access the deserialized data using `.get()`
@@ -82,7 +82,7 @@ fn process_data() {
 
 1. We derive `Yokeable` on our `Message<'a>` struct. This tells `yoke` how to handle the lifetimes.
 2. We use `Yoke::attach_to_cart`. We pass it our `Storage` instance (which takes ownership of it) and a closure.
-3. The closure receives a `&[u8]` slice that is guaranteed to live as long as the `Storage` instance. We use FlatMessage's `deserialize_from_slice` to parse the data.
+3. The closure receives a `&StorageRef` object that is guaranteed to live as long as the `Storage` instance. We use FlatMessage's `deserialize_from_ref` to parse the data.
 4. The resulting `Yoke<Message<'static>, Storage>` is a self-contained, owned type. It has no lifetime parameters and can be returned from functions, stored in structs, or sent across threads (if the underlying types are `Send`).
 5. When you need to access the data, you call `.get()`, which returns a reference tied to the lifetime of the `Yoke` object itself.
 

--- a/flat_message/Cargo.toml
+++ b/flat_message/Cargo.toml
@@ -12,17 +12,19 @@ keywords = ["serialization", "deserialize", "serialize", "zero-copy", "schema-le
 categories = ["encoding"]
 
 [dependencies]
-# flat_message_proc_macro = { path = "../flat_message_proc_macro" }
-flat_message_proc_macro = "0.2.0"
+flat_message_proc_macro = { path = "../flat_message_proc_macro" }
+# flat_message_proc_macro = "0.2.0"
 serde = { version = "1", optional = true }
 crc32fast = "1"
 smallvec = { version = "1.15.1", optional = true }
+stable_deref_trait = { version = "1.2.1", default-features = false, optional = true }
 
 [features]
 default = []
 check_crc32 = []
 benchmarks = ["dep:serde"]
 smallvec = ["flat_message_proc_macro/smallvec", "dep:smallvec"]
+stable_deref = ["dep:stable_deref_trait"]
 
 [lints]
 workspace = true

--- a/flat_message/src/flat_message.rs
+++ b/flat_message/src/flat_message.rs
@@ -3,10 +3,24 @@ use crate::{Config, Storage};
 
 pub trait FlatMessage<'a> {
     fn serialize_to(&self, output: &mut Storage, config: Config) -> Result<(), Error>;
+    fn deserialize_from_slice(input: &'a [u8]) -> Result<Self, Error>
+    where
+        Self: Sized;
+    unsafe fn deserialize_from_slice_unchecked(input: &'a [u8]) -> Result<Self, Error>
+    where
+        Self: Sized;
+
     fn deserialize_from(input: &'a Storage) -> Result<Self, Error>
     where
-        Self: Sized;
+        Self: Sized,
+    {
+        Self::deserialize_from_slice(input.as_slice())
+    }
+
     unsafe fn deserialize_from_unchecked(input: &'a Storage) -> Result<Self, Error>
     where
-        Self: Sized;
+        Self: Sized,
+    {
+        unsafe { Self::deserialize_from_slice_unchecked(input.as_slice()) }
+    }
 }

--- a/flat_message/src/flat_message.rs
+++ b/flat_message/src/flat_message.rs
@@ -1,12 +1,12 @@
 use crate::error::Error;
-use crate::{Config, Storage};
+use crate::{Config, Storage, StorageRef};
 
 pub trait FlatMessage<'a> {
     fn serialize_to(&self, output: &mut Storage, config: Config) -> Result<(), Error>;
-    fn deserialize_from_slice(input: &'a [u8]) -> Result<Self, Error>
+    fn deserialize_from_ref(input: &'a StorageRef) -> Result<Self, Error>
     where
         Self: Sized;
-    unsafe fn deserialize_from_slice_unchecked(input: &'a [u8]) -> Result<Self, Error>
+    unsafe fn deserialize_from_ref_unchecked(input: &'a StorageRef) -> Result<Self, Error>
     where
         Self: Sized;
 
@@ -14,13 +14,13 @@ pub trait FlatMessage<'a> {
     where
         Self: Sized,
     {
-        Self::deserialize_from_slice(input.as_slice())
+        Self::deserialize_from_ref(input.as_ref())
     }
 
     unsafe fn deserialize_from_unchecked(input: &'a Storage) -> Result<Self, Error>
     where
         Self: Sized,
     {
-        unsafe { Self::deserialize_from_slice_unchecked(input.as_slice()) }
+        unsafe { Self::deserialize_from_ref_unchecked(input.as_ref()) }
     }
 }

--- a/flat_message/src/lib.rs
+++ b/flat_message/src/lib.rs
@@ -27,6 +27,7 @@ pub use self::serde::SerDeSlice;
 pub use self::serde::SerDeVec;
 pub use self::serde::SerDeVecType;
 pub use self::storage::Storage;
+pub use self::storage::StorageRef;
 pub use self::structure_information::StructureInformation;
 
 pub use flat_message_proc_macro::*;

--- a/flat_message/src/storage.rs
+++ b/flat_message/src/storage.rs
@@ -79,6 +79,10 @@ impl Storage {
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         unsafe { slice::from_raw_parts_mut(self.vec.as_mut_ptr() as *mut u8, self.size) }
     }
+
+    pub fn as_ref(&self) -> &StorageRef {
+        StorageRef::from_storage(self)
+    }
 }
 
 impl Debug for Storage {
@@ -93,14 +97,34 @@ impl PartialEq<Storage> for Storage {
     }
 }
 
-#[cfg(feature = "stable_deref")]
 impl std::ops::Deref for Storage {
-    type Target = [u8];
+    type Target = StorageRef;
 
     fn deref(&self) -> &Self::Target {
-        self.as_slice()
+        self.as_ref()
     }
 }
 
 #[cfg(feature = "stable_deref")]
 unsafe impl stable_deref_trait::StableDeref for Storage {}
+
+/// Wraps a raw byte slice that is known to be aligned to a 128-bit boundary.
+/// This pattern is simiarily used (but with a different invariant) in CString / CStr.
+/// (CStr itself is a #[repr(transparent)] struct over a raw byte slice, with the invariant that it ends with a nul byte.)
+#[repr(transparent)]
+pub struct StorageRef([u8]);
+
+impl StorageRef {
+    pub fn from_storage(storage: &Storage) -> &Self {
+        // # Safety:
+        // The storage only returns us a slice that is guaranteed to be aligned to a 128-bit boundary.
+        // We can safely transmute the slice to a &StorageRef due to the repr(transparent).
+        // This is the same pattern used to convert from a &CString to a &Cstr,
+        // although with a pointer cast instead of a transmute.
+        unsafe { std::mem::transmute(storage.as_slice()) }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}

--- a/flat_message/src/storage.rs
+++ b/flat_message/src/storage.rs
@@ -92,3 +92,15 @@ impl PartialEq<Storage> for Storage {
         self.as_slice() == other.as_slice()
     }
 }
+
+#[cfg(feature = "stable_deref")]
+impl std::ops::Deref for Storage {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+#[cfg(feature = "stable_deref")]
+unsafe impl stable_deref_trait::StableDeref for Storage {}

--- a/flat_message/src/structure_information.rs
+++ b/flat_message/src/structure_information.rs
@@ -25,12 +25,11 @@ impl StructureInformation {
     }
 }
 
-impl TryFrom<&Storage> for StructureInformation {
+impl TryFrom<&[u8]> for StructureInformation {
     type Error = Error;
 
-    fn try_from(buf: &Storage) -> Result<Self, Self::Error> {
+    fn try_from(buf: &[u8]) -> Result<Self, Self::Error> {
         // validate buf length - minimum 8 bytes
-        let buf = buf.as_slice();
         let len = buf.len();
         if len < size_of::<headers::HeaderV1>() {
             return Err(Error::InvalidHeaderLength(len));
@@ -87,5 +86,13 @@ impl TryFrom<&Storage> for StructureInformation {
             name,
             version: NonZeroU8::new(header.version),
         })
+    }
+}
+
+impl TryFrom<&Storage> for StructureInformation {
+    type Error = Error;
+
+    fn try_from(buf: &Storage) -> Result<Self, Self::Error> {
+        Self::try_from(buf.as_slice())
     }
 }

--- a/flat_message/src/structure_information.rs
+++ b/flat_message/src/structure_information.rs
@@ -1,4 +1,4 @@
-use crate::{buffer, headers, Error, Name, Storage};
+use crate::{buffer, headers, Error, Name, Storage, StorageRef};
 use crate::common::constants;
 use std::mem::size_of;
 use std::num::{NonZeroU32, NonZeroU64, NonZeroU8};
@@ -25,11 +25,12 @@ impl StructureInformation {
     }
 }
 
-impl TryFrom<&[u8]> for StructureInformation {
+impl TryFrom<&StorageRef> for StructureInformation {
     type Error = Error;
 
-    fn try_from(buf: &[u8]) -> Result<Self, Self::Error> {
+    fn try_from(buf: &StorageRef) -> Result<Self, Self::Error> {
         // validate buf length - minimum 8 bytes
+        let buf = buf.as_slice();
         let len = buf.len();
         if len < size_of::<headers::HeaderV1>() {
             return Err(Error::InvalidHeaderLength(len));
@@ -93,6 +94,6 @@ impl TryFrom<&Storage> for StructureInformation {
     type Error = Error;
 
     fn try_from(buf: &Storage) -> Result<Self, Self::Error> {
-        Self::try_from(buf.as_slice())
+        Self::try_from(buf.as_ref())
     }
 }

--- a/flat_message_proc_macro/src/struct_info.rs
+++ b/flat_message_proc_macro/src/struct_info.rs
@@ -503,7 +503,6 @@ impl<'a> StructInfo<'a> {
 
         quote! {
                 use ::std::ptr;
-                let input = input.as_slice();
                 enum RefOffsetSize {
                     U8,
                     U16,
@@ -875,13 +874,13 @@ impl<'a> StructInfo<'a> {
             }
         } else {
             quote! {
-                Self::deserialize_from(input)
+                Self::deserialize_from_slice(input)
             }
         };
 
 
         quote! {
-            fn deserialize_from(input: & #lifetimes ::flat_message::Storage) -> core::result::Result<Self,flat_message::Error>
+            fn deserialize_from_slice(input: & #lifetimes [u8]) -> core::result::Result<Self,flat_message::Error>
             {
                 #header_deserialization_code
                 #checksum_check_code
@@ -900,7 +899,7 @@ impl<'a> StructInfo<'a> {
                     }
                 }
             }
-            unsafe fn deserialize_from_unchecked(input: & #lifetimes ::flat_message::Storage) -> core::result::Result<Self,flat_message::Error>
+            unsafe fn deserialize_from_slice_unchecked(input: & #lifetimes [u8]) -> core::result::Result<Self,flat_message::Error>
             {
                 #unchecked_code
             }

--- a/flat_message_proc_macro/src/struct_info.rs
+++ b/flat_message_proc_macro/src/struct_info.rs
@@ -508,6 +508,7 @@ impl<'a> StructInfo<'a> {
                     U16,
                     U32,
                 }
+                let input = input.as_slice();
                 let len = input.len();
                 if len < 8 {
                     return Err(flat_message::Error::InvalidHeaderLength(len));
@@ -874,13 +875,13 @@ impl<'a> StructInfo<'a> {
             }
         } else {
             quote! {
-                Self::deserialize_from_slice(input)
+                Self::deserialize_from_ref(input)
             }
         };
 
 
         quote! {
-            fn deserialize_from_slice(input: & #lifetimes [u8]) -> core::result::Result<Self,flat_message::Error>
+            fn deserialize_from_ref(input: & #lifetimes flat_message::StorageRef) -> core::result::Result<Self,flat_message::Error>
             {
                 #header_deserialization_code
                 #checksum_check_code
@@ -899,7 +900,7 @@ impl<'a> StructInfo<'a> {
                     }
                 }
             }
-            unsafe fn deserialize_from_slice_unchecked(input: & #lifetimes [u8]) -> core::result::Result<Self,flat_message::Error>
+            unsafe fn deserialize_from_ref_unchecked(input: & #lifetimes flat_message::StorageRef) -> core::result::Result<Self,flat_message::Error>
             {
                 #unchecked_code
             }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 [dependencies]
 flat_message = { path = "../flat_message" }
 smallvec = { version = "1.15.1", optional = true }
+yoke = { version = "0.8.1", features = ["derive"], optional = true }
 
 [lints]
 workspace = true
 
 [features]
 smallvec = ["dep:smallvec", "flat_message/smallvec"]
+stable_deref = ["flat_message/stable_deref", "yoke"]

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -40,6 +40,9 @@ mod default_values;
 #[cfg(all(feature = "smallvec", test))]
 mod with_smallvec;
 
+#[cfg(all(feature = "stable_deref", test))]
+mod with_stable_deref;
+
 #[cfg(test)]
 pub(crate) use flat_message::{Config, FlatMessage, Storage};
 #[cfg(test)]

--- a/tests/src/with_smallvec.rs
+++ b/tests/src/with_smallvec.rs
@@ -72,7 +72,7 @@ fn check_option_smallvec_repr() {
     }
     let t = Test {
         v1: Some(SmallVec::from_slice(&[1, 2, 3, 4])),
-        v2: Some(Smallvec::from(&["Hello".to_string(), "xyz".to_string()])),
+        v2: Some(SmallVec::from(["Hello".to_string(), "xyz".to_string()])),
         v3: None,
     };
     let mut s = Storage::default();
@@ -176,7 +176,11 @@ fn check_smallvec_object() {
     {
         let mut v = Storage::default();
         let t = Test {
-            s1: smallvec!["Hello".to_string(), "World".to_string(), "Everyone".to_string()],
+            s1: smallvec![
+                "Hello".to_string(),
+                "World".to_string(),
+                "Everyone".to_string()
+            ],
             s2: smallvec!["abc", "xyz", "123"],
         };
         {

--- a/tests/src/with_stable_deref.rs
+++ b/tests/src/with_stable_deref.rs
@@ -15,8 +15,8 @@ fn minimal_yoked() {
     let mut storage = Storage::default();
     t.serialize_to(&mut storage, Config::default()).unwrap();
 
-    let yoked = Yoke::<Test, Storage>::attach_to_cart(storage, |slice| {
-        Test::deserialize_from_slice(slice).expect("Failed to deserialize")
+    let yoked = Yoke::<Test, Storage>::attach_to_cart(storage, |storage_ref| {
+        Test::deserialize_from_ref(storage_ref).expect("Failed to deserialize")
     });
 
     assert_eq!(&t, yoked.get());
@@ -52,8 +52,8 @@ fn check_simple_serde_yoked() {
     let mut storage = Storage::default();
     t.serialize_to(&mut storage, Config::default()).unwrap();
 
-    let yoked = Yoke::<Test, Storage>::attach_to_cart(storage, |slice| {
-        Test::deserialize_from_slice(slice).expect("Failed to deserialize")
+    let yoked = Yoke::<Test, Storage>::attach_to_cart(storage, |storage_ref| {
+        Test::deserialize_from_ref(storage_ref).expect("Failed to deserialize")
     });
 
     assert_eq!(&t, yoked.get());
@@ -90,8 +90,8 @@ fn check_borrowed_serde_yoked() {
     let mut storage = Storage::default();
     t.serialize_to(&mut storage, Config::default()).unwrap();
 
-    let yoked = Yoke::<Test, Storage>::attach_to_cart(storage, |slice| {
-        Test::deserialize_from_slice(slice).expect("Failed to deserialize")
+    let yoked = Yoke::<Test, Storage>::attach_to_cart(storage, |storage_ref| {
+        Test::deserialize_from_ref(storage_ref).expect("Failed to deserialize")
     });
 
     assert_eq!(&t, yoked.get());
@@ -113,9 +113,9 @@ fn mdbook_example() {
 
     // 2. Attach the deserialized structure to the Storage "cart"
     // The resulting `yoked` object owns the storage and can be moved around!
-    let yoked: Yoke<Message<'static>, Storage> = Yoke::attach_to_cart(storage, |slice| {
-        // Deserialize from the slice provided by yoke
-        Message::deserialize_from_slice(slice).expect("Failed to deserialize")
+    let yoked: Yoke<Message<'static>, Storage> = Yoke::attach_to_cart(storage, |storage_ref| {
+        // Deserialize from the the ref provided by yoke
+        Message::deserialize_from_ref(storage_ref).expect("Failed to deserialize")
     });
 
     // 3. Access the deserialized data using `.get()`

--- a/tests/src/with_stable_deref.rs
+++ b/tests/src/with_stable_deref.rs
@@ -1,0 +1,126 @@
+use flat_message::*;
+use yoke::{Yoke, Yokeable};
+
+#[test]
+fn minimal_yoked() {
+    #[derive(FlatMessage, Debug, PartialEq, Eq, Yokeable)]
+    struct Test<'a> {
+        a: &'a str,
+        b: u8,
+    }
+
+    // Heap-allocated string (not 'static)
+    let hello = "Hello".to_owned();
+    let t = Test { a: &hello, b: 1 };
+    let mut storage = Storage::default();
+    t.serialize_to(&mut storage, Config::default()).unwrap();
+
+    let yoked = Yoke::<Test, Storage>::attach_to_cart(storage, |slice| {
+        Test::deserialize_from_slice(slice).expect("Failed to deserialize")
+    });
+
+    assert_eq!(&t, yoked.get());
+}
+
+#[test]
+fn check_simple_serde_yoked() {
+    #[derive(FlatMessageStruct, Debug, PartialEq, Eq)]
+    struct MyDataV1 {
+        a: u8,
+        b: u32,
+        c: u16,
+        d: String,
+    }
+    #[derive(FlatMessage, Debug, PartialEq, Eq, Yokeable)]
+    #[flat_message_options(store_name = false)]
+    struct Test {
+        x: u8,
+        #[flat_message_item(align = 4, kind = struct)]
+        d: MyDataV1,
+        a: u8,
+    }
+    let t = Test {
+        x: 1,
+        d: MyDataV1 {
+            a: 2,
+            b: 3,
+            c: 4,
+            d: "Hello".to_string(),
+        },
+        a: 5,
+    };
+    let mut storage = Storage::default();
+    t.serialize_to(&mut storage, Config::default()).unwrap();
+
+    let yoked = Yoke::<Test, Storage>::attach_to_cart(storage, |slice| {
+        Test::deserialize_from_slice(slice).expect("Failed to deserialize")
+    });
+
+    assert_eq!(&t, yoked.get());
+}
+
+#[test]
+fn check_borrowed_serde_yoked() {
+    #[derive(FlatMessageStruct, Debug, PartialEq, Eq)]
+    struct MyDataV1<'a> {
+        a: u8,
+        b: u32,
+        c: u16,
+        d: &'a str,
+    }
+    #[derive(FlatMessage, Debug, PartialEq, Eq, Yokeable)]
+    #[flat_message_options(store_name = false)]
+    struct Test<'a> {
+        x: u8,
+        #[flat_message_item(align = 4, kind = struct)]
+        d: MyDataV1<'a>,
+        a: u8,
+    }
+    let hello = "Hello".to_string();
+    let t = Test {
+        x: 1,
+        d: MyDataV1 {
+            a: 2,
+            b: 3,
+            c: 4,
+            d: hello.as_str(),
+        },
+        a: 5,
+    };
+    let mut storage = Storage::default();
+    t.serialize_to(&mut storage, Config::default()).unwrap();
+
+    let yoked = Yoke::<Test, Storage>::attach_to_cart(storage, |slice| {
+        Test::deserialize_from_slice(slice).expect("Failed to deserialize")
+    });
+
+    assert_eq!(&t, yoked.get());
+}
+
+#[test]
+fn mdbook_example() {
+    // 1. Derive Yokeable on your structure
+    #[derive(FlatMessage, Debug, PartialEq, Eq, Yokeable)]
+    struct Message<'a> {
+        content: &'a str,
+        id: u32,
+    }
+
+    // Create and serialize some data
+    let original = Message { content: "Hello, World!", id: 42 };
+    let mut storage = Storage::default();
+    original.serialize_to(&mut storage, Config::default()).unwrap();
+
+    // 2. Attach the deserialized structure to the Storage "cart"
+    // The resulting `yoked` object owns the storage and can be moved around!
+    let yoked: Yoke<Message<'static>, Storage> = Yoke::attach_to_cart(storage, |slice| {
+        // Deserialize from the slice provided by yoke
+        Message::deserialize_from_slice(slice).expect("Failed to deserialize")
+    });
+
+    // 3. Access the deserialized data using `.get()`
+    let message: &Message<'_> = yoked.get();
+    
+    assert_eq!(message.content, "Hello, World!");
+    assert_eq!(message.id, 42);
+}


### PR DESCRIPTION
- Refactored the required FlatMessage methods to work on slices instead of the Storage directly
- Added default implementations for the original `deserialize_from[_unchecked](input: &'a Storage)` based on the new `deserialize_from_slice[_unchecked]` methods
- Updated tests
- Added StableDeref implementations to Storage to be compatible with Yoke (behind the `stable_deref` feature)
- Added a book chapter on using Yoke to move around owned zero-copy structures